### PR TITLE
Allow variables prefixed with `var`, or no prefix at all

### DIFF
--- a/src/javascript/__init__.py
+++ b/src/javascript/__init__.py
@@ -25,7 +25,7 @@ def read_js(p: pathlib.Path | str, *, varname: str) -> typing.Any:
     with open(p) as in_file:
         contents = in_file.read()
 
-    m = re.compile(r"^const %s = " % varname)
+    m = re.compile(r"^(?:const |var )?%s = " % varname)
 
     if not m.match(contents):
         raise ValueError(

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -7,11 +7,17 @@ from javascript import append_to_js_array, read_js, write_js
 
 
 class TestReadJs:
-    def test_can_read_file(self, tmp_path: pathlib.Path) -> None:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};\n',
+            'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};',
+            'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n}',
+        ],
+    )
+    def test_can_read_file(self, tmp_path: pathlib.Path, text: str) -> None:
         js_path = tmp_path / "shape.js"
-        js_path.write_text(
-            'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};\n'
-        )
+        js_path.write_text(text)
 
         assert read_js(js_path, varname="redPentagon") == {"sides": 5, "colour": "red"}
 
@@ -36,12 +42,6 @@ class TestReadJs:
             ValueError, match="does not start with JavaScript `const` declaration"
         ):
             read_js(js_path, varname="blueTriangle")
-
-    def test_allows_trailing_semicolon(self, tmp_path: pathlib.Path) -> None:
-        js_path = tmp_path / "shape.js"
-        js_path.write_text('const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n}')
-
-        assert read_js(js_path, varname="redPentagon") == {"sides": 5, "colour": "red"}
 
 
 class TestWriteJs:

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -11,6 +11,8 @@ class TestReadJs:
         "text",
         [
             'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};\n',
+            'var redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};\n',
+            'redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};\n',
             'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n};',
             'const redPentagon = {\n  "sides": 5,\n  "colour": "red"\n}',
         ],


### PR DESCRIPTION
Closes #7